### PR TITLE
make the game playable with love-11.1

### DIFF
--- a/helpers.lua
+++ b/helpers.lua
@@ -68,7 +68,7 @@ function boringLoad()
 
     music = {}
     for i,filename in pairs(love.filesystem.getDirectoryItems("music")) do
-        music[filename:sub(1,-5)] = love.audio.newSource("music/"..filename)
+        music[filename:sub(1,-5)] = love.audio.newSource("music/"..filename, "stream")
         music[filename:sub(1,-5)]:setLooping(true)
     end
 


### PR DESCRIPTION
This prevents a stack trace on startup:

Error: slam.lua:58: bad argument #2 to 'newInstance' (string expected, got nil)
stack traceback:
	[string "boot.lua"]:637: in function <[string "boot.lua"]:633>
	[C]: in function 'newInstance'
	slam.lua:58: in function 'play'
	main.lua:12: in function 'load'
	[string "boot.lua"]:488: in function <[string "boot.lua"]:487>
	[C]: in function 'xpcall'
	[string "boot.lua"]:650: in function <[string "boot.lua"]:639>
	[C]: in function 'xpcall'